### PR TITLE
feat: Enable emitDecoratorMetadata option

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
       "noFallthroughCasesInSwitch": true,
       "preserveConstEnums": true,
       "experimentalDecorators": true,
+      "emitDecoratorMetadata": true,
       "preserveSymlinks": true,
       "resolveJsonModule": true,
       "sourceMap": true,


### PR DESCRIPTION
Enabling this option makes decorators more useful. When this option is
enabled and the `reflect-metadata` library has been imported, additional
design-time type information is exposed at runtime for declarations that
have decorators. See [this article][1] for an example.

Enabling this option allows a kind of programmatic Reflection, which is
useful and may be required for TypeScript ORMs and Dependency Injection
frameworks.

Enabling this option for all projects is safe because when the
`reflect-metadata` library is not present as a dependency of your
project, this option has no effect.

[1]: https://www.typescriptlang.org/docs/handbook/decorators.html#metadata