### PR TITLE
feat: use es2019 for lib and target

### DIFF
--- a/browser/tsconfig.commonjs.json
+++ b/browser/tsconfig.commonjs.json
@@ -2,7 +2,7 @@
    "extends": "../tsconfig.commonjs.json",
    "compilerOptions": {
       "lib": [
-         "es2016",
+         "es2019",
          "dom"
       ]
    }

--- a/browser/tsconfig.esm.json
+++ b/browser/tsconfig.esm.json
@@ -2,7 +2,7 @@
    "extends": "../tsconfig.esm.json",
    "compilerOptions": {
       "lib": [
-         "es2016",
+         "es2019",
          "dom"
       ]
    }

--- a/browser/tsconfig.json
+++ b/browser/tsconfig.json
@@ -2,7 +2,7 @@
    "extends": "../tsconfig.json",
    "compilerOptions": {
       "lib": [
-         "es2016",
+         "es2019",
          "dom"
       ]
    }

--- a/browser/tsconfig.types.json
+++ b/browser/tsconfig.types.json
@@ -2,7 +2,7 @@
    "extends": "../tsconfig.types.json",
    "compilerOptions": {
       "lib": [
-         "es2016",
+         "es2019",
          "dom"
       ]
    }

--- a/tsconfig.commonjs.json
+++ b/tsconfig.commonjs.json
@@ -1,7 +1,6 @@
 {
    "extends": "./tsconfig.json",
    "compilerOptions": {
-      "target": "es5",
       "noEmit": false
    }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
    "compilerOptions": {
-      "target": "es2016",
+      "target": "es2019",
       "lib": [
-         "es2016"
+         "es2019"
       ],
       "module": "commonjs",
       "strict": true,


### PR DESCRIPTION
We are currently using node 12 in all of our node TypeScript projects,
and we are beginning to use babel to transpile front-end projects. So,
to take advantage of new features in TypeScript/JavaScript we need to
increase our tsconfig lib and target settings. Since node 12 supports
all of es2019, this seems a good version to target.

Also, as we upgrade to the current version of TypeScript (3.9.2) some of
the functionality that was allowed in previous versions of TypeScript
when targeting "es5" now require tslib. For example, array spread notation
now requires tslib to transpile to es5.