### PR TITLE
Add compiler options that support TS 4 and Vue 3

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
       "noUnusedLocals": true,
       "strictNullChecks": true,
       "forceConsistentCasingInFileNames": true,
+      "jsx": "preserve",
       "moduleResolution": "node",
       "esModuleInterop": true,
       "allowSyntheticDefaultImports": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
       "noUnusedLocals": true,
       "strictNullChecks": true,
       "forceConsistentCasingInFileNames": true,
+      "useUnknownInCatchVariables": false,
       "jsx": "preserve",
       "moduleResolution": "node",
       "esModuleInterop": true,


### PR DESCRIPTION
The `jsx` option enables Vue tooling to have excellent type-checking and IntelliSense in template code. (49a4dcf2d4df3e3bf561ab132cfa3caf66079d4b)

The `useUnknownInCatchVariables` option being set to `false` enables us to upgrade to TypeScript 4 without needing to update all catch blocks that use the error object. (8e889ea1abaed771a11cd19f5458506ae6ab21c9)