### PR TITLE
feat: bump target and lib from es2019 to es2023

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
    "compilerOptions": {
-      "target": "es2019",
+      "target": "es2023",
       "lib": [
-         "es2019"
+         "es2023"
       ],
       "module": "commonjs",
       "strict": true,


### PR DESCRIPTION
Node 20 fully supports ES2023, and all active Silvermine projects are on Node 20+.

Browser variants are left at es2019 due to legacy browser support concerns.